### PR TITLE
Basic Spinner Integration

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -22,6 +22,7 @@ The future state of this project aims to provide a unified interface for Jira on
 - [x] Users can send queries to ChatGPT and the frontend will render the markdown responce
 - [x] The UI renders screen size changes.
 - [x] `esc` exits the application.
+- [x] Interactive 'Loading ...' is now present so user knows something is running in backround ...
 
 # Demo
 

--- a/helpers/chatgpt_helpers.go
+++ b/helpers/chatgpt_helpers.go
@@ -22,28 +22,36 @@ import (
 	"fmt"
 	"os"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sashabaranov/go-openai"
 )
 
-func GetChatCompletion(txt string) (string, error) {
-	apiKey := os.Getenv("OPENAI_API_KEY")
-	client := openai.NewClient(apiKey)
-	resp, err := client.CreateChatCompletion(
-		context.Background(),
-		openai.ChatCompletionRequest{
-			Model: openai.GPT4oLatest,
-			Messages: []openai.ChatCompletionMessage{
-				{
-					Role:    openai.ChatMessageRoleUser,
-					Content: txt,
+type FetchedDataMsg struct {
+	Data string
+	Err  error
+}
+
+func GetChatCompletion(txt string) tea.Cmd {
+	return func() tea.Msg {
+		apiKey := os.Getenv("OPENAI_API_KEY")
+		client := openai.NewClient(apiKey)
+		resp, err := client.CreateChatCompletion(
+			context.Background(),
+			openai.ChatCompletionRequest{
+				Model: openai.GPT4oLatest,
+				Messages: []openai.ChatCompletionMessage{
+					{
+						Role:    openai.ChatMessageRoleUser,
+						Content: txt,
+					},
 				},
 			},
-		},
-	)
+		)
 
-	if err != nil {
-		return "", fmt.Errorf("ChatCompletion error: %v", err)
+		if err != nil {
+			return FetchedDataMsg{Data: "", Err: fmt.Errorf("ChatCompletion error: %v", err)}
+		}
+
+		return FetchedDataMsg{Data: resp.Choices[0].Message.Content, Err: nil}
 	}
-
-	return resp.Choices[0].Message.Content, nil
 }


### PR DESCRIPTION
This example as of now can send queries to chatgpt and issue a dynamic loading text prompt to the viewport and clear when the data is ready to be displayed.